### PR TITLE
Enhancement for file uploader and file manager

### DIFF
--- a/client/src/components/JSONSchemaForm/CustomCodeMirror.js
+++ b/client/src/components/JSONSchemaForm/CustomCodeMirror.js
@@ -210,6 +210,7 @@ export default class CustomCodeMirror extends Component {
           options={cmOptions}
         />
         <FileManagerModal
+          dir={this.props.options.file_dir}
           handleSelect={::this.handleModalSelect}
           onclose={::this.onModalClose}
           isOpen={this.state.modalIsOpen}

--- a/client/src/components/JSONSchemaForm/CustomCodeMirror.js
+++ b/client/src/components/JSONSchemaForm/CustomCodeMirror.js
@@ -190,7 +190,7 @@ export default class CustomCodeMirror extends Component {
   }
 
   handleModalSelect(filePath) {
-    const img = `![](/${filePath})`;
+    const img = `![](${filePath})`;
     const editor = this.refs.cmBody.getCodeMirror();
     editor.replaceSelection(img + editor.getSelection());
   }

--- a/client/src/components/JSONSchemaForm/FilePickerWidget.js
+++ b/client/src/components/JSONSchemaForm/FilePickerWidget.js
@@ -39,7 +39,6 @@ export default class FilePickerWidget extends Component {
     } = this.props;
 
     const { modalIsOpen } = this.state;
-
     return (
       <div>
         <span className="file-picker" id={id}>
@@ -59,6 +58,7 @@ export default class FilePickerWidget extends Component {
           </button>
         </span>
         <FileManagerModal
+          dir={options.file_dir}
           handleSelect={::this.handleModalSelect}
           onclose={::this.onModalClose}
           isOpen={modalIsOpen}

--- a/client/src/components/Modal/FileManagerModal.js
+++ b/client/src/components/Modal/FileManagerModal.js
@@ -16,7 +16,7 @@ export default class FileManagerModal extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      selectedFolderPath: '/',
+      selectedFolderPath: this.getDefaultPath(props.dir),
       disableSelectBtn: true
     };
   }
@@ -24,10 +24,17 @@ export default class FileManagerModal extends Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.isOpen && !this.props.isOpen) {
       this.setState({
-        selectedFolderPath: '/',
+        selectedFolderPath: this.getDefaultPath(nextProps.dir),
         disableSelectBtn: true
       });
     }
+  }
+
+  getDefaultPath(dir) {
+    if (dir) {
+      return dir.indexOf('/') === 0 ? dir : '/' + dir;
+    }
+    return '/';
   }
 
   fileCallback(filepath) {
@@ -49,6 +56,7 @@ export default class FileManagerModal extends Component {
 
   render() {
     const {
+      dir,
       isOpen,
       onclose,
       treeMeta,
@@ -75,6 +83,7 @@ export default class FileManagerModal extends Component {
         </header>
         <section className="body">
           <FileManager
+            defaultPath={dir}
             treeMeta={treeMeta}
             currentBranch={currentBranch}
             fetchRepoTree={fetchRepoTree}

--- a/client/src/components/common/FileManager.js
+++ b/client/src/components/common/FileManager.js
@@ -39,17 +39,19 @@ export default class FileManager extends Component {
     super(props);
     this.state = {
       updating: false,
-      gridView: false,
-      currentPath: '/',
-      records: props.treeMeta && parseFileTree(props.treeMeta)
+      gridView: false
     };
   }
 
   componentWillMount() {
-    const { fetchRepoTree, currentBranch } = this.props;
-    fetchRepoTree(currentBranch).then(data => {
-      this.setState({ records: parseFileTree(data.tree) });
-    });
+    const { treeMeta, fetchRepoTree, currentBranch, defaultPath } = this.props;
+    if (treeMeta) {
+      this.setInitialRecordsAndPath(treeMeta, defaultPath);
+    } else {
+      fetchRepoTree(currentBranch).then(data => {
+        this.setInitialRecordsAndPath(data.tree, defaultPath);
+      });
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -78,6 +80,25 @@ export default class FileManager extends Component {
         });
       }
     }
+  }
+
+  setInitialRecordsAndPath(treeMeta, defaultPath) {
+    let currRecords = parseFileTree(treeMeta);
+    let currPath = '/';
+    if (defaultPath) {
+      try {
+        currPath =
+          defaultPath.indexOf('/') === 0 ? defaultPath : '/' + defaultPath;
+        currRecords = parseFolderObj(defaultPath, currRecords);
+      } catch (err) {
+        console.log(defaultPath, ' is not existing path');
+      }
+      console.log(defaultPath, currRecords);
+    }
+    this.setState({
+      currentPath: currPath,
+      records: currRecords
+    });
   }
 
   handleFileClick(file) {
@@ -226,18 +247,28 @@ export default class FileManager extends Component {
           </div>
           <div className="view-control">
             <button
-              className={gridView ? 'button tooltip-bottom icon' : 'button tooltip-bottom icon active'}
-              onClick={::this.handleListView}>
+              className={
+                gridView
+                  ? 'button tooltip-bottom icon'
+                  : 'button tooltip-bottom icon active'
+              }
+              onClick={::this.handleListView}
+            >
               <svg className="icon-svg icon-view_list">
-                <use xlinkHref="#icon-view_list"></use>
+                <use xlinkHref="#icon-view_list" />
               </svg>
               <span>List view</span>
             </button>
             <button
-              className={gridView ? 'button tooltip-bottom icon active' : 'button tooltip-bottom icon'}
-              onClick={::this.handleGridView}>
+              className={
+                gridView
+                  ? 'button tooltip-bottom icon active'
+                  : 'button tooltip-bottom icon'
+              }
+              onClick={::this.handleGridView}
+            >
               <svg className="icon-svg icon-view_module">
-                <use xlinkHref="#icon-view_module"></use>
+                <use xlinkHref="#icon-view_module" />
               </svg>
               <span>Icon view</span>
             </button>

--- a/client/src/components/common/FileManager.js
+++ b/client/src/components/common/FileManager.js
@@ -140,7 +140,7 @@ export default class FileManager extends Component {
   handleListView() {
     const { gridView, records } = this.state;
     if (gridView) {
-      let newCont = records['_contents'].map(r => ({
+      let newCont = records['_contents'].map(f => ({
         name: f.name,
         path: f.path
       }));
@@ -196,37 +196,53 @@ export default class FileManager extends Component {
 
     return (
       <div className="file-manager">
-        <div className="view-control">
-          <button onClick={::this.handleListView}>List View</button>
-          <button onClick={::this.handleGridView}>Icon View</button>
-        </div>
-        <div className="breadcrumb">
-          <a
-            onClick={() => {
-              this.setState({
-                currentPath: '/',
-                records: treeMeta && parseFileTree(treeMeta)
-              });
-            }}
-          >
-            <HomeIcon />
-          </a>/
-          {parseFolderPath(currentPath).map((folder, idx) => {
-            return (
-              <span key={idx}>
-                &nbsp;
-                <a
-                  onClick={this.handleBreadscrumLink.bind(
-                    this,
-                    folder.pathArray
-                  )}
-                >
-                  {folder.name}&nbsp;/
-                </a>
-              </span>
-            );
-          })}
-        </div>
+        <header>
+          <div className="breadcrumb">
+            <a
+              onClick={() => {
+                this.setState({
+                  currentPath: '/',
+                  records: treeMeta && parseFileTree(treeMeta)
+                });
+              }}
+            >
+              <HomeIcon />
+            </a>/
+            {parseFolderPath(currentPath).map((folder, idx) => {
+              return (
+                <span key={idx}>
+                  &nbsp;
+                  <a
+                    onClick={this.handleBreadscrumLink.bind(
+                      this,
+                      folder.pathArray
+                    )}
+                  >
+                    {folder.name}&nbsp;/
+                  </a>
+                </span>
+              );
+            })}
+          </div>
+          <div className="view-control">
+            <button
+              className={gridView ? 'button tooltip-bottom icon' : 'button tooltip-bottom icon active'}
+              onClick={::this.handleListView}>
+              <svg className="icon-svg icon-view_list">
+                <use xlinkHref="#icon-view_list"></use>
+              </svg>
+              <span>List view</span>
+            </button>
+            <button
+              className={gridView ? 'button tooltip-bottom icon active' : 'button tooltip-bottom icon'}
+              onClick={::this.handleGridView}>
+              <svg className="icon-svg icon-view_module">
+                <use xlinkHref="#icon-view_module"></use>
+              </svg>
+              <span>Icon view</span>
+            </button>
+          </div>
+        </header>
         <NestedFileTreeView
           className={gridView ? 'grid-view' : ''}
           selectedFilePath={this.state.selectedFile}

--- a/client/src/components/common/NestedFileTree/FileView.js
+++ b/client/src/components/common/NestedFileTree/FileView.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const FileView = props => {
+  let { file, fileClickHandler, selectedFilePath, fileTemplate } = props;
+
+  let fileClassName = (props.fileClassName || '') + ' item nft-item';
+  let selectedClassName = props.selectedClassName || 'active';
+  let cns =
+    selectedFilePath === file.path
+      ? selectedClassName + ' ' + fileClassName
+      : fileClassName;
+  let onclickFn = () => {
+    fileClickHandler && fileClickHandler(file);
+  };
+
+  return (
+    <div key={`file-${file.path}`} className={cns} onClick={onclickFn}>
+      {(fileTemplate && fileTemplate(file)) ||
+        <a>
+          |__{file.name}
+        </a>}
+    </div>
+  );
+};
+
+export default FileView;

--- a/client/src/components/common/NestedFileTree/FolderView.js
+++ b/client/src/components/common/NestedFileTree/FolderView.js
@@ -1,0 +1,107 @@
+import React, { Component } from 'react';
+import FileView from './FileView';
+
+class FolderView extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: props.expended || false
+    };
+  }
+
+  toggleFolder() {
+    const { open } = this.state;
+    const { name, parentPath, folderObj } = this.props;
+    const currentPath = parentPath + '/' + name;
+
+    this.setState({ open: !open }, () => {
+      let fn = this.props.folderClickHandler;
+      fn && fn(name, currentPath, folderObj);
+    });
+  }
+
+  render() {
+    const {
+      level,
+      name,
+      parentPath,
+      folderObj,
+      maxFolderLevel,
+      expended,
+      folderTemplate,
+      fileTemplate,
+      fileClassName,
+      folderClassName,
+      fileClickHandler,
+      selectedFilePath,
+      folderClickHandler
+    } = this.props;
+    const { open } = this.state;
+    let styl = open ? { display: 'block' } : { display: 'none' };
+    let cns = (folderClassName || '') + ' subFolder nft-item';
+    let passedFolderProps = {
+      maxFolderLevel,
+      expended,
+      folderTemplate,
+      fileTemplate,
+      fileClickHandler,
+      fileClassName,
+      folderClassName,
+      selectedFilePath,
+      folderClickHandler
+    };
+
+    return (
+      <div key={`folder-${name}`} className={open ? `open ${cns}` : cns}>
+        {(folderTemplate &&
+          folderTemplate({
+            name,
+            folderObj,
+            currentPath: parentPath + '/' + name,
+            onclick: this.toggleFolder.bind(this)
+          })) ||
+          <a onClick={::this.toggleFolder}>
+            /{name}
+          </a>}
+
+        <div style={styl} data-level={level} className="nft-container">
+          {folderObj &&
+            folderObj['_contents'].map(f => {
+              return (
+                <FileView
+                  key={`file-${f.path}`}
+                  file={f}
+                  fileTemplate={fileTemplate}
+                  fileClickHandler={fileClickHandler}
+                  fileClassName={fileClassName}
+                  selectedFilePath={selectedFilePath}
+                />
+              );
+            })}
+          {(parseInt(maxFolderLevel) && maxFolderLevel > level) ||
+          isNaN(parseInt(maxFolderLevel))
+            ? folderObj &&
+              Object.keys(folderObj)
+                .filter(k => {
+                  return k !== '_contents';
+                })
+                .map(prop => {
+                  return (
+                    <FolderView
+                      key={`folder-${name}-${prop}`}
+                      level={level + 1}
+                      name={prop}
+                      parentPath={parentPath + '/' + name}
+                      folderObj={folderObj[prop]}
+                      {...passedFolderProps}
+                    />
+                  );
+                })
+            : <span className="more">...</span>}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default FolderView;

--- a/client/src/components/common/NestedFileTree/index.js
+++ b/client/src/components/common/NestedFileTree/index.js
@@ -1,0 +1,82 @@
+import React, { PropTypes } from 'react';
+import FileView from './FileView';
+import FolderView from './FolderView';
+
+function NestedFileTreeView(props) {
+  const {
+    directory,
+    maxFolderLevel,
+    expended,
+    className,
+    fileClickHandler,
+    folderClickHandler,
+    fileClassName,
+    folderClassName,
+    selectedFilePath,
+    selectedClassName,
+    fileTemplate,
+    folderTemplate
+  } = props;
+
+  const passedProps = {
+    fileClickHandler,
+    fileClassName,
+    folderClassName,
+    selectedFilePath,
+    selectedClassName,
+    fileTemplate
+  };
+
+  return (
+    <div data-level="0" className={'nft-container ' + (className || '')}>
+      {directory &&
+        directory['_contents'].map(file => {
+          return (
+            <FileView
+              key={`root-file-${file.path}`}
+              file={file}
+              {...passedProps}
+            />
+          );
+        })}
+      {directory &&
+        Object.keys(directory)
+          .filter(k => {
+            return k !== '_contents';
+          })
+          .map(prop => {
+            return (
+              <FolderView
+                key={`root-folder-${prop}`}
+                level={1}
+                expended={expended}
+                maxFolderLevel={maxFolderLevel}
+                folderObj={directory[prop]}
+                name={prop}
+                parentPath=""
+                folderClickHandler={folderClickHandler}
+                folderTemplate={folderTemplate}
+                {...passedProps}
+              />
+            );
+          })}
+    </div>
+  );
+}
+
+NestedFileTreeView.propTypes = {
+  directory: PropTypes.object.isRequired,
+  maxFolderLevel: PropTypes.number,
+  expended: PropTypes.bool,
+  className: PropTypes.string,
+  fileClickHandler: PropTypes.func,
+  folderClickHandler: PropTypes.func,
+  fileClassName: PropTypes.string,
+  folderClassName: PropTypes.string,
+  selectedFilePath: PropTypes.string,
+  selectedClassName: PropTypes.string,
+  folderTemplate: PropTypes.func,
+  fileTemplate: PropTypes.func
+};
+
+export default NestedFileTreeView;

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -62,6 +62,14 @@
     <path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"/>
     <path d="M0 0h24v24H0z" fill="none"/>
   </symbol>
+  <symbol id="icon-view_list" viewBox="0 0 24 24">
+    <title>view_list</title>
+    <path d="M9 5.016h12v3.984h-12v-3.984zM9 18.984v-3.984h12v3.984h-12zM9 14.016v-4.031h12v4.031h-12zM3.984 9v-3.984h4.031v3.984h-4.031zM3.984 18.984v-3.984h4.031v3.984h-4.031zM3.984 14.016v-4.031h4.031v4.031h-4.031z"></path>
+  </symbol>
+  <symbol id="icon-view_module" viewBox="0 0 24 24">
+  <title>view_module</title>
+  <path d="M15.984 5.016h5.016v6h-5.016v-6zM9.984 11.016v-6h5.016v6h-5.016zM15.984 18v-6h5.016v6h-5.016zM9.984 18v-6h5.016v6h-5.016zM3.984 18v-6h5.016v6h-5.016zM3.984 11.016v-6h5.016v6h-5.016z"></path>
+  </symbol>
   </defs>
   </svg>
   <div id="js-app">

--- a/client/src/styles/_nested_file_tree.scss
+++ b/client/src/styles/_nested_file_tree.scss
@@ -1,0 +1,76 @@
+.nft-container {
+  a {
+    border-radius: 2px;
+    border-left: 4px solid transparent;
+    display: block;
+    color: inherit;
+    margin-bottom: 3px;
+    cursor: pointer;
+    text-decoration: none;
+    border-bottom: 1px solid $light;
+    padding: $space/3 1.5*$space/2;
+    &:hover {
+      text-decoration: none;
+      background: #eee;
+    }
+  }
+
+  .nft-item {
+    &:last-child {
+      a {
+        border-bottom: 0;
+      }
+    }
+    svg {
+      fill: $grey;
+      height: 1.5*$space/2;
+      vertical-align: text-top;
+    }
+  }
+
+  &.grid-view {
+    display: flex;
+    width: 100%;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    
+    .nft-item {
+      width: 33%;
+      align-self: baseline;
+      > a {
+        border: none;
+        min-height: 80px;
+        text-align: center;
+        margin: 0;
+      
+        > .name {
+          display: block;
+        }
+
+        img {
+          max-width: 100%;
+          max-height: 80px;
+        }
+      }
+    }
+
+  }
+}
+  
+.nft-item {
+  .nft-container {
+    margin-left: 18px;
+  }
+  &:active,
+  &.active {
+    background: #0A93FF;
+    a {
+      background: $blue;
+      color: #FFF;
+      svg {
+        fill: tint($blue, 80%);
+      }
+    }
+  }
+}

--- a/client/src/styles/_sass/main.scss
+++ b/client/src/styles/_sass/main.scss
@@ -7,6 +7,7 @@
 
 @import 'partials/_base';
 @import 'partials/_codemirror';
+@import 'partials/_icon';
 
 #landing {
   @import 'partials/_landing';

--- a/client/src/styles/_sass/partials/_icon.scss
+++ b/client/src/styles/_sass/partials/_icon.scss
@@ -1,0 +1,8 @@
+.icon-svg {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  stroke-width: 0;
+  stroke: currentColor;
+  fill: currentColor;
+}

--- a/client/src/styles/_sass/partials/app/_all.scss
+++ b/client/src/styles/_sass/partials/app/_all.scss
@@ -1,3 +1,4 @@
 @import '_content';
 @import '_header';
 @import '_modal';
+@import '_file_manager';

--- a/client/src/styles/_sass/partials/app/_file_manager.scss
+++ b/client/src/styles/_sass/partials/app/_file_manager.scss
@@ -1,0 +1,61 @@
+.file-manager {
+  .breadcrumb {
+    border-bottom: 1px solid $light;
+    color: $grey;
+    display: inline-block;
+    width: 80%;
+    @include font-size($small);
+    line-height: 140%;
+    padding: $space/3 1.5*$space/2;
+    a {
+      color: $black;
+      @include transition-property(color);
+      @include transition-duration($ease);
+      svg {
+        fill: $black;
+        height: 2*$space/3;
+        vertical-align: text-bottom;
+        width: 2*$space/3;
+        @include transition-property(fill);
+        @include transition-duration($ease);
+      }
+      &:hover {
+        color: $blue;
+        text-decoration: none;
+        svg {
+          fill: $blue;
+        }
+      }
+    }
+  }
+  .view-control {
+    display: inline-block;
+
+    .button {
+      border: none;
+      background: transparent;
+      opacity: 0.7;
+      &.active {
+        opacity: 1;
+      }
+    }
+  }
+  .footer {
+    .confirm-filename,
+    .confirm-destination {
+      box-sizing: border-box;
+      float: left;
+      width: 50%;
+      input {
+        width: 100%;
+      }
+    }
+    .confirm-filename {
+
+      padding-right: $space/2;
+    }
+    .confirm-destination {
+      padding-left: $space/2;
+    }
+  }
+}

--- a/client/src/styles/_sass/partials/app/_modal.scss
+++ b/client/src/styles/_sass/partials/app/_modal.scss
@@ -24,33 +24,6 @@
     border-top: 1px solid $line;
   }
   &.file-picker {
-    .breadcrumb {
-      border-bottom: 1px solid $light;
-      color: $grey;
-      @include font-size($small);
-      line-height: 140%;
-      padding: $space/3 1.5*$space/2;
-      a {
-        color: $black;
-        @include transition-property(color);
-        @include transition-duration($ease);
-        svg {
-          fill: $black;
-          height: 2*$space/3;
-          vertical-align: text-bottom;
-          width: 2*$space/3;
-          @include transition-property(fill);
-          @include transition-duration($ease);
-        }
-        &:hover {
-          color: $blue;
-          text-decoration: none;
-          svg {
-            fill: $blue;
-          }
-        }
-      }
-    }
     .body {
       padding: 0;
       ul {
@@ -90,24 +63,6 @@
             vertical-align: text-top;
           }
         }
-      }
-    }
-    .footer {
-      .confirm-filename,
-      .confirm-destination {
-        box-sizing: border-box;
-        float: left;
-        width: 50%;
-        input {
-          width: 100%;
-        }
-      }
-      .confirm-filename {
-
-        padding-right: $space/2;
-      }
-      .confirm-destination {
-        padding-left: $space/2;
       }
     }
   }

--- a/client/src/styles/_supplement.scss
+++ b/client/src/styles/_supplement.scss
@@ -1,7 +1,7 @@
 /* special styles for react components */
 
 @import './_sass/main.scss';
-
+@import './_nested_file_tree.scss';
 @include font-face('icon', '../assets/icons/icons');
 
 #js-app {


### PR DESCRIPTION
Refer to https://github.com/Wiredcraft/jekyllpro/issues/33

- Implemented list view and icon view for file manager
- If in the schema file it has `ui:options` to specify the default upload folder, then set to that path when opening the file uploader.
   ```
  "uiSchema": {
    "body": {
      "ui:widget": "customCodeMirror",
      "ui:help": "Description of the product",
      "ui:options": {
        "file_dir": "images/products"
      }
    },
   ````
