### PR TITLE
disallow file path editing if file_path_readonly is set to true 

### DIFF
--- a/client/src/components/Editor/ContentEditor.js
+++ b/client/src/components/Editor/ContentEditor.js
@@ -538,9 +538,11 @@ export default class ContentEditor extends Component {
                 <strong>File path: </strong>
                 {currentFilePath}
                 {'  '}
-                (<a href="javascript:;" onClick={this.handleShowFilename}>
-                  edit
-                </a>)
+                {!this.props.config.file_path_readonly && (
+                  <a href="javascript:;" onClick={this.handleShowFilename}>
+                    ( edit )
+                  </a>
+                )}
               </small>
             : null}
         </div>

--- a/client/src/components/Editor/NewEditor.js
+++ b/client/src/components/Editor/NewEditor.js
@@ -441,9 +441,11 @@ export default class NewEditor extends Component {
                 <strong>File path: </strong>
                 {currentFilePath}
                 {'  '}
-                (<a href="javascript:;" onClick={this.handleShowFilename}>
-                  edit
-                </a>)
+                {!this.props.config.file_path_readonly && (
+                  <a href="javascript:;" onClick={this.handleShowFilename}>
+                    ( edit )
+                  </a>
+                )}
               </small>
             : null}
         </div>


### PR DESCRIPTION
in `_config.yml`, using this to control the file path editing.
```
jekyllpro_cms_config:
  file_path_readonly: true
```