### PR TITLE
Display possible site url on editor if jekyllpro enabled

### DIFF
--- a/client/src/actions/editorActions.js
+++ b/client/src/actions/editorActions.js
@@ -93,3 +93,12 @@ export function selectCollectionFile(item) {
     });
   };
 }
+
+export function setBuildSiteUrl(url) {
+  return dispatch => {
+    dispatch({
+      payload: { buildSiteUrl: url },
+      type: CHANGE_EDITOR_STATE
+    });
+  };
+}

--- a/client/src/components/Editor.js
+++ b/client/src/components/Editor.js
@@ -71,6 +71,7 @@ function mapStateToProps(
     collections: repoState.collections,
     selectedCollectionFile: editorState.selectedCollectionFile,
     defaultFileValues: editorState.defaultValues,
+    buildSiteUrl: editorState.buildSiteUrl,
     editorUpdating: editorState.loading
   };
 }

--- a/client/src/components/Editor/ContentEditor.js
+++ b/client/src/components/Editor/ContentEditor.js
@@ -574,6 +574,38 @@ export default class ContentEditor extends Component {
     this.setState({ formData: res.formData, fileModified: true });
   };
 
+  getBuildSitePath() {
+    const { formData, currentFileLanguage } = this.state;
+    let path = null;
+    if (!formData.category) {
+      return path;
+    }
+    path = formData.category.join('/');
+    if (currentFileLanguage && this.isDefaultLanguage()) {
+      return path;
+    }
+    if (currentFileLanguage) {
+      return currentFileLanguage + '/' + path;
+    }
+  }
+
+  renderBuildSiteUrl = () => {
+    const { config, buildSiteUrl } = this.props;
+    let sitePath = this.getBuildSitePath() || '';
+    let siteUrl = buildSiteUrl + '/' + sitePath;
+    if (!config.displayBuildUrl || !buildSiteUrl) {
+      return null;
+    }
+    return (
+      <small className="meta">
+        Content in this file may appearing on
+        <a href={siteUrl} target="_blank">
+          {' '}{siteUrl}
+        </a>
+      </small>
+    );
+  };
+
   render() {
     const {
       editorUpdating,
@@ -639,21 +671,25 @@ export default class ContentEditor extends Component {
         />
 
         <div className="body">
-          <small className="meta">
-            <strong>{selectedCollectionFile.collectionType}</strong>&nbsp;
-            <a
-              className="edit tooltip-bottom"
-              href={`${repoUrl}commit/${selectedCollectionFile.lastCommitSha}`}
-              target="_blank"
-            >
-              Updated&nbsp;
-              {moment(
-                Date.parse(selectedCollectionFile.lastUpdatedAt)
-              ).fromNow()}&nbsp; by&nbsp;
-              {selectedCollectionFile.lastUpdatedBy}
-              <span>View on GitHub</span>
-            </a>
-          </small>
+          <div className="meta">
+            <small>
+              <strong>{selectedCollectionFile.collectionType}</strong>&nbsp;
+              <a
+                className="edit tooltip-bottom"
+                href={`${repoUrl}commit/${selectedCollectionFile.lastCommitSha}`}
+                target="_blank"
+              >
+                Updated&nbsp;
+                {moment(
+                  Date.parse(selectedCollectionFile.lastUpdatedAt)
+                ).fromNow()}&nbsp; by&nbsp;
+                {selectedCollectionFile.lastUpdatedBy}
+                <span>View on GitHub</span>
+              </a>
+            </small>
+            {this.renderBuildSiteUrl()}
+          </div>
+
           {parsorError &&
             <div className="error-msg-block">
               Unable to parse fields properly as {parsorError}

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -14,6 +14,7 @@ import {
   retryIndexFetchRequest
 } from '../actions/repoActions';
 import {
+  setBuildSiteUrl,
   resetEditorData,
   selectCollectionFile
 } from '../actions/editorActions';
@@ -345,6 +346,7 @@ function mapStateToProps(
   { params: { collectionType, branch, splat: path } }
 ) {
   var repoStatus = state.repo.toJSON();
+  var editorStatus = state.editor.toJSON();
   return {
     currentBranch: repoStatus.currentBranch,
     avatar: state.user.get('avatar'),
@@ -356,7 +358,8 @@ function mapStateToProps(
     repoUpdateSignal: repoStatus.repoUpdateSignal,
     currentBranchUpdatedAt: repoStatus.currentBranchUpdatedAt,
     indexUpdatedAt: repoStatus.indexUpdatedAt,
-    indexFetchStatus: repoStatus.indexFetchStatus
+    indexFetchStatus: repoStatus.indexFetchStatus,
+    buildSiteUrl: editorStatus.buildSiteUrl
   };
 }
 
@@ -374,7 +377,8 @@ function mapDispatchToProps(dispatch) {
       fetchRepoIndex,
       fetchUpdatedCollections,
       resetUpdateSignal,
-      retryIndexFetchRequest
+      retryIndexFetchRequest,
+      setBuildSiteUrl
     },
     dispatch
   );

--- a/client/src/components/Header/JekyllProStatus.js
+++ b/client/src/components/Header/JekyllProStatus.js
@@ -26,7 +26,12 @@ export default class JekyllProStatus extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     const { updating } = this.state;
-    const { currentBranch, repoUpdateSignal } = this.props;
+    const {
+      currentBranch,
+      repoUpdateSignal,
+      setBuildSiteUrl,
+      buildSiteUrl
+    } = this.props;
 
     if (updating) {
       return;
@@ -50,6 +55,10 @@ export default class JekyllProStatus extends Component {
             },
             updating: false
           });
+
+          if (res.url !== buildSiteUrl) {
+            setBuildSiteUrl(res.url);
+          }
         })
         .catch(err => {
           console.log(err);
@@ -63,7 +72,7 @@ export default class JekyllProStatus extends Component {
   }
 
   handleHover() {
-    const { currentBranch } = this.props;
+    const { currentBranch, setBuildSiteUrl, buildSiteUrl } = this.props;
     const { buildStatus, updating } = this.state;
 
     // do not update when last update was three seconds ago
@@ -89,6 +98,9 @@ export default class JekyllProStatus extends Component {
             lastUpdate: Date.now()
           }
         });
+        if (res.url !== buildSiteUrl) {
+          setBuildSiteUrl(res.url);
+        }
       })
       .catch(err => {
         console.log(err);


### PR DESCRIPTION
Getting the build live site domain from jekyllpro service, and the relative site path is calculated based on the `:category` field( ⚠️  hard-coded permalink logic for now 😞 ). 
Also indicated on `_cms-setting.yml` as a feature switch:
```
displayBuildUrl: true
```